### PR TITLE
注文機能

### DIFF
--- a/app/controllers/users/order_items_controller.rb
+++ b/app/controllers/users/order_items_controller.rb
@@ -1,0 +1,5 @@
+class Users::OrderItemsController < Users::ApplicationController
+  def index
+    @order_items = current_user.order_items.preload(:order, product: { image_attachment: :blob }).order_by_latest
+  end
+end

--- a/app/controllers/users/orders_controller.rb
+++ b/app/controllers/users/orders_controller.rb
@@ -1,0 +1,19 @@
+class Users::OrdersController < Users::ApplicationController
+  def show
+    @cart_items = current_cart.cart_items.preload(product: { image_attachment: :blob }).order_by_latest
+  end
+
+  def create
+    products = Product.where(id: params[:product_ids])
+    total_price, payment_amount, cash_on_delivery, shipping_fee = params.values_at(:total_price, :payment_amount, :cash_on_delivery, :shipping_fee).map(&:to_i)
+    if current_cart.has_ordered_products?(products)
+      flash[:error] = 'カート内に注文済み商品が含まれていたため、注文はキャンセルされました。'
+    elsif !products.price_correct?(total_price)
+      flash[:error] = 'カート内商品の金額が変更されたので、注文はキャンセルされました。'
+    else
+      Order.confirm_order(current_cart, products, payment_amount, cash_on_delivery, shipping_fee)
+      flash[:notice] = '注文が完了しました。'
+    end
+    redirect_to carts_path
+  end
+end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -4,4 +4,8 @@ class Cart < ApplicationRecord
   has_many :products, through: :cart_items
 
   delegate :include?, to: :products
+
+  def has_ordered_products?(products)
+    products.any? { |product| self.user.ordered?(product) }
+  end
 end

--- a/app/models/concerns/taxable.rb
+++ b/app/models/concerns/taxable.rb
@@ -1,0 +1,9 @@
+module Taxable
+  extend ActiveSupport::Concern
+
+  TAX_RATE = '1.10'.freeze
+
+  def self.including_tax(price)
+    (BigDecimal(price.to_s) * BigDecimal(TAX_RATE)).floor
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,41 @@
+class Order < ApplicationRecord
+  include Taxable
+
+  belongs_to :user
+  has_many :order_items, dependent: :destroy
+  has_many :products, through: :order_items
+
+  validates :payment_amount, :cash_on_delivery, :shipping_fee, presence: true, numericality: { greater_than: 0 }
+
+  scope :default_order, -> { order(:id) }
+
+  SHIPPING_FEE_RATE = 600
+
+  def self.confirm_order(cart, products, payment_amount, cash_on_delivery, shipping_fee)
+    order = cart.user.orders.build(payment_amount:, cash_on_delivery:, shipping_fee:)
+    products.each do |product|
+      order.order_items.build(product:, price: product.price_including_tax)
+    end
+    order.save!
+    cart.cart_items.where(product: products).destroy_all
+  end
+
+  def self.taxed_cash_on_delivery(price)
+    base_price = case price
+                 when 0...10_000
+                   300
+                 when 10_000...30_000
+                   400
+                 when 30_000...100_000
+                   600
+                 else
+                   1_000
+                 end
+    Taxable.including_tax(base_price)
+  end
+
+  def self.taxed_shipping_fee(amount)
+    base_price = BigDecimal((amount / 5.0).to_s).ceil * SHIPPING_FEE_RATE
+    Taxable.including_tax(base_price)
+  end
+end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -1,0 +1,9 @@
+class OrderItem < ApplicationRecord
+  belongs_to :order
+  belongs_to :product
+
+  validates :price, presence: true, numericality: { greater_than: 0 }
+  validates :order_id, uniqueness: { scope: :product_id }
+
+  scope :order_by_latest, -> { order(created_at: :desc) }
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -15,4 +15,9 @@ class Product < ApplicationRecord
   def in_cart?(cart)
     cart.include?(self)
   end
+
+  def self.price_correct?(total_price)
+    taxed_price = self.pluck(:price).map { |price| Taxable.including_tax(price) }
+    taxed_price.sum == total_price
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,9 +2,15 @@ class User < ApplicationRecord
   devise :database_authenticatable, :validatable, :registerable, :rememberable, :confirmable
 
   has_one :cart, dependent: :destroy
+  has_many :orders, dependent: :destroy
+  has_many :order_items, through: :orders
 
   validates :name, presence: true
   validates :address, presence: true
 
   scope :default_order, -> { order(:id) }
+
+  def ordered?(product)
+    order_items.exists?(product:)
+  end
 end

--- a/app/views/carts/show.html.haml
+++ b/app/views/carts/show.html.haml
@@ -28,6 +28,9 @@
                   %th 合計
                   %td.fw-bolder.fs-5.text-end
                     = number_to_currency(total_price)
-            -# TODO: 注文モデル実装後パス変更
-            = link_to 'レジに進む', root_path, class: 'btn btn-accent w-100'
+            = link_to 'レジに進む', users_orders_path, class: 'btn btn-accent w-100'
             = link_to '買い物を続ける', root_path, class: 'btn btn-secondary w-100 mt-3'
+    - else
+      .col-md-12.bg-white.p-3
+        %p.text-center カートに商品は入っていません。
+        .text-center= link_to '買い物を続ける', root_path, class: 'btn btn-accent w-50 mt-3'

--- a/app/views/layouts/users/application.html.haml
+++ b/app/views/layouts/users/application.html.haml
@@ -15,7 +15,9 @@
         %ul.navbar-nav
           - if user_signed_in?
             %li.nav-item.d-flex.align-items-center
-              = link_to carts_path, class: 'btn btn-accent' do
+              = link_to '注文履歴', users_order_items_path, class: 'btn btn-accent'
+            %li.nav-item.d-flex.align-items-center
+              = link_to carts_path, class: 'btn btn-accent ms-2' do
                 %i.bi.bi-bag
                 %span.ms-1 カート
             %li.nav-item

--- a/app/views/users/order_items/index.html.haml
+++ b/app/views/users/order_items/index.html.haml
@@ -1,0 +1,15 @@
+.col-md-6.offset-md-3.mt-5
+  %h1.fs-5 注文履歴
+  - @order_items.each do |order_item|
+    .card.mb-3
+      .row
+        .col-md-2= product_image_tag(order_item.product, 200, 150)
+        .col-md-10
+          .card-body
+            %h5.card-title
+              = link_to order_item.product.name, product_path(order_item.product), class: 'text-decoration-none'
+            %p.m-0
+              注文日：
+              = l order_item.order.created_at, format: :long
+            %p
+              #{number_to_currency(order_item.price)}（税込）

--- a/app/views/users/orders/show.html.haml
+++ b/app/views/users/orders/show.html.haml
@@ -1,0 +1,47 @@
+.col-md-6.offset-md-3.mt-5
+  .row
+    .col-md-7.bg-white.p-3
+      .h5.fw-bolder ご注文商品の確認
+      %p.text-danger.fw-bolder.small ※注文はまだ確定していません
+      .mt-2
+        %p.small.m-0 以下の商品の注文を行います。
+        %p.small 表示されている商品が正しいかもう一度お確かめください。
+      - total_price = 0
+      - @cart_items.each do |cart_item|
+        - total_price += cart_item.product.price_including_tax
+        .row.border-bottom.mb-3
+          .col-md-1.p-0
+            = product_image_tag(cart_item.product, 100, 50)
+          .col-md-11
+            .d-flex.justify-content-between.fs-5
+              .name= link_to cart_item.product.name, product_path(cart_item.product), class: 'text-decoration-none'
+              .price
+                = number_to_currency(cart_item.product.price_including_tax)
+                %span.small （税込）
+
+    .col-md-4.offset-md-1
+      .card
+        .card-body
+          %h5.card-title ご請求額
+          %table.table.table-striped
+            %tbody
+              %tr
+                %th 小計
+                %td.text-end= number_to_currency(total_price)
+              %tr
+                %th 代引き手数料
+                - cash_on_delivery = Order.taxed_cash_on_delivery(total_price)
+                %td.text-end= number_to_currency(cash_on_delivery)
+              %tr
+                %th 送料
+                - shipping_fee = Order.taxed_shipping_fee(@cart_items.count)
+                %td.text-end= number_to_currency(shipping_fee)
+              %tr
+                %th 合計
+                - payment_amount = [total_price, cash_on_delivery, shipping_fee].sum
+                %td.fw-bolder.fs-5.text-end= number_to_currency(payment_amount)
+          %p.fw-bolder 支払方法：代引き決済
+          = button_to '注文を確定する',
+                      users_orders_path(product_ids: @cart_items.pluck(:product_id), total_price:, payment_amount:, cash_on_delivery:, shipping_fee:),
+                      method: :post,
+                      class: 'btn btn-success w-100'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,11 @@ Rails.application.routes.draw do
     root 'top#index'
   end
 
+  namespace :users do
+    resource :orders, only: %i[show create]
+    resources :order_items, only: :index
+  end
+
   resource :carts, only: :show do
     resources :cart_items, only: %i[create destroy], module: :carts
   end

--- a/db/migrate/20240929055122_create_orders.rb
+++ b/db/migrate/20240929055122_create_orders.rb
@@ -1,0 +1,11 @@
+class CreateOrders < ActiveRecord::Migration[7.1]
+  def change
+    create_table :orders do |t|
+      t.integer :payment_amount, null: false
+      t.integer :cash_on_delivery, null: false
+      t.integer :shipping_fee, null: false
+      t.references :user, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240929055136_create_order_items.rb
+++ b/db/migrate/20240929055136_create_order_items.rb
@@ -1,0 +1,11 @@
+class CreateOrderItems < ActiveRecord::Migration[7.1]
+  def change
+    create_table :order_items do |t|
+      t.integer :price, null: false
+      t.references :order, null: false, foreign_key: true, index: false
+      t.references :product, null: false, foreign_key: true
+      t.timestamps
+    end
+    add_index :order_items, %i[order_id product_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_24_133628) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_29_055136) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -67,6 +67,26 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_24_133628) do
     t.index ["user_id"], name: "index_carts_on_user_id", unique: true
   end
 
+  create_table "order_items", force: :cascade do |t|
+    t.integer "price", null: false
+    t.bigint "order_id", null: false
+    t.bigint "product_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["order_id", "product_id"], name: "index_order_items_on_order_id_and_product_id", unique: true
+    t.index ["product_id"], name: "index_order_items_on_product_id"
+  end
+
+  create_table "orders", force: :cascade do |t|
+    t.integer "payment_amount", null: false
+    t.integer "cash_on_delivery", null: false
+    t.integer "shipping_fee", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_orders_on_user_id"
+  end
+
   create_table "products", force: :cascade do |t|
     t.string "name", null: false
     t.integer "price", null: false
@@ -101,4 +121,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_24_133628) do
   add_foreign_key "cart_items", "carts"
   add_foreign_key "cart_items", "products"
   add_foreign_key "carts", "users"
+  add_foreign_key "order_items", "orders"
+  add_foreign_key "order_items", "products"
+  add_foreign_key "orders", "users"
 end

--- a/spec/factories/order_items.rb
+++ b/spec/factories/order_items.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :order_item do
+    price { 1_000 }
+    order { nil }
+    product { nil }
+  end
+end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :order do
+    total_price { 1_000 }
+    cash_on_delivery { 330 }
+    user { nil }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,5 +8,9 @@ FactoryBot.define do
     trait :confirmed do
       confirmed_at { 1.day.ago }
     end
+
+    trait :with_cart do
+      cart
+    end
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,30 @@
+describe Order do
+  describe '#confirm_order' do
+    it '注文が完了する' do
+      user = create(:user, :confirmed, :with_cart)
+      create(:cart_item, cart: user.cart, product: create(:product, name: 'トマト', price: 198))
+      create(:cart_item, cart: user.cart, product: create(:product, name: 'レタス', price: 298))
+      expect do
+        Order.confirm_order(user.cart, user.cart.products, 544, 330, 660)
+      end.to change(Order, :count).by(1).and change(OrderItem, :count).by(2).and change(CartItem, :count).by(-2)
+    end
+  end
+
+  describe '#taxed_cash_on_delivery' do
+    it '代引き手数料が正しく計算される' do
+      expect(Order.taxed_cash_on_delivery(9_999)).to eq 330
+      expect(Order.taxed_cash_on_delivery(29_999)).to eq 440
+      expect(Order.taxed_cash_on_delivery(99_999)).to eq 660
+      expect(Order.taxed_cash_on_delivery(999_999)).to eq 1_100
+    end
+  end
+
+  describe '#taxed_shipping_fee' do
+    it '送料が正しく計算される' do
+      expect(Order.taxed_shipping_fee(5)).to eq 660
+      expect(Order.taxed_shipping_fee(10)).to eq 1_320
+      expect(Order.taxed_shipping_fee(15)).to eq 1_980
+      expect(Order.taxed_shipping_fee(20)).to eq 2_640
+    end
+  end
+end

--- a/spec/system/users/orders_spec.rb
+++ b/spec/system/users/orders_spec.rb
@@ -1,0 +1,109 @@
+describe '注文' do
+  describe '作成' do
+    it 'カートに入れた商品を注文できる' do
+      user = create(:user, :confirmed, :with_cart)
+      create(:cart_item, cart: user.cart, product: create(:product, name: 'トマト', price: 198))
+      create(:cart_item, cart: user.cart, product: create(:product, name: 'レタス', price: 298))
+      sign_in user
+      visit carts_path
+      click_link 'レジに進む'
+      expect(page).to have_content 'ご注文商品の確認'
+      expect(page).to have_content 'トマト'
+      expect(page).to have_content 'レタス'
+      expect(page).to have_content '1,534円'
+      click_button '注文を確定する'
+      expect(page).to have_content '注文が完了しました。'
+      expect(page).to have_content 'カートに商品は入っていません。'
+    end
+
+    it '２つのタブで操作した場合、注文確認画面に表示されている商品のみ注文される' do
+      product = create(:product, :published, name: 'トマト')
+      another_product = create(:product, :published, name: 'レタス')
+      user = create(:user, :confirmed)
+      sign_in user
+
+      # タブ1でトマトをカートに追加しレジに進む
+      visit product_path(product)
+      click_button 'カートに入れる'
+      expect(page).to have_content 'カートに追加しました。'
+      visit carts_path
+      click_link 'レジに進む'
+      expect(page).to have_content 'ご注文商品の確認'
+      expect(page).to have_content 'トマト'
+
+      # タブ2でレタスをカートに追加しレジに進む
+      page.within_window(page.open_new_window) do
+        visit product_path(another_product)
+        click_button 'カートに入れる'
+        expect(page).to have_content 'カートに追加しました。'
+        visit carts_path
+        click_link 'レジに進む'
+        expect(page).to have_content 'ご注文商品の確認'
+        expect(page).to have_content 'トマト'
+        expect(page).to have_content 'レタス'
+      end
+
+      # タブ1でトマトの注文を確定する
+      click_button '注文を確定する'
+      expect(page).to have_content '注文が完了しました。'
+
+      # トマトのみ注文される
+      expect(page).to have_content 'カートに入っている商品'
+      expect(page).not_to have_content 'トマト'
+      expect(OrderItem.exists?(product_id: product.id)).to be true
+      expect(page).to have_content 'レタス'
+      expect(OrderItem.exists?(product_id: another_product.id)).to be false
+    end
+
+    it '2つのタブで注文操作した場合、重複して商品が注文されない' do
+      product = create(:product, :published, name: 'トマト')
+      user = create(:user, :confirmed)
+      sign_in user
+
+      # タブ1でトマトをカートに追加しレジに進む
+      visit product_path(product)
+      click_button 'カートに入れる'
+      expect(page).to have_content 'カートに追加しました。'
+      visit carts_path
+      click_link 'レジに進む'
+      expect(page).to have_content 'ご注文商品の確認'
+      expect(page).to have_content 'トマト'
+
+      # タブ2でトマトの注文を確定する
+      page.within_window(page.open_new_window) do
+        visit users_orders_path
+        click_button '注文を確定する'
+        expect(page).to have_content '注文が完了しました。'
+      end
+
+      # タブ1でトマトの注文を確定するが注文されない
+      click_button '注文を確定する'
+      expect(page).to have_content 'カート内に注文済み商品が含まれていたため、注文はキャンセルされました。'
+      expect(page).to have_content 'カートに商品は入っていません。'
+    end
+
+    it 'カートに商品を追加後、商品の金額が変更された場合、注文されない' do
+      # ユーザーは198円+税の商品をカートに追加
+      user = create(:user, :confirmed, :with_cart)
+      product = create(:product, name: 'トマト', price: 198)
+      create(:cart_item, cart: user.cart, product:)
+      sign_in user
+      visit users_orders_path
+
+      # 管理者が商品を298円に値上げ
+      product.update!(price: 298)
+
+      # ユーザーは198円+税のまま注文を確定する
+      expect(page).to have_content 'ご注文商品の確認'
+      expect(page).to have_content 'トマト'
+      expect(page).to have_content '217円'
+      click_button '注文を確定する'
+
+      # 注文されず、金額が修正される
+      expect(page).to have_content 'カート内商品の金額が変更されたので、注文はキャンセルされました。'
+      expect(page).to have_content 'カートに入っている商品'
+      expect(page).to have_content 'トマト'
+      expect(page).to have_content '327円'
+    end
+  end
+end


### PR DESCRIPTION
Orderモデルの作成
OrderItemモデルの作成
カート画面からレジに進むボタンをクリックする
　注文のルーティング追加
　レジに進むボタンのパス修正

注文確認画面で金額、商品の最終確認をする
　ビューの追加（order/show）
　ビュー内で金額の計算をする
　　送料の計算メソッドの作成(商品数/5切り上げ × 600)
　　代引き手数料の計算メソッドの作成
　　　0-10,000円未満：300円
　　　10,000-30,000円未満：400円
　　　30,000-100,000円未満：600円
　　　100,000円以上：1,000円

問題なければ注文確定ボタンを押す
注文が確定し、カートの中が削除される
　orders_controllerの作成

注文が重複していないか確認する
　has_ordered_products?メソッドの作成

ビューで表示した金額とDB内の金額が合っているか確認する
　price_correct?メソッドの作成

注文履歴に商品が表示される
　ビューの追加（order_items/index）

税額の計算メソッドの作成
　金額+10％
　models/concerns/taxable.rbの追加

### 画面
![スクリーンショット 2024-10-01 23 24 35](https://github.com/user-attachments/assets/e684f6e6-bb72-49f7-b6b3-91429a5ab0c4)
![スクリーンショット 2024-10-01 23 24 42](https://github.com/user-attachments/assets/186df936-ea04-4c1a-8253-68345bbae505)
